### PR TITLE
Fix paho-mqtt version to 1.6.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM osrf/ros:humble-desktop
 WORKDIR /root
 
 RUN apt update && apt install -y python3-pip
-RUN pip install "paho-mqtt<2.0.0" 
+RUN pip install "paho-mqtt==1.6.1"
 RUN pip install ruamel.yaml
 
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This package bridges ROS2 (RMF Lift and Door Adapter) to LCI.
 # System requirements
 - ROS2 Humble
 - Python packages
-  - paho-mqtt < 2.0.0
+  - paho-mqtt == 1.6.1
   - ruamel.yaml
 
 The more detail is exemplified in [Dockerfile](Dockerfile).
@@ -111,6 +111,6 @@ LCI does not only support the elevators (lifts) and the doors but also,
 - the exclusive control of resoruces among multiple robot systems (**LCI Sem**)
 - the messaging service between robots and humans (**LCI Bell**)
 
-To use full functionaly of LCI, please use MQTT.  
+To use full functionaly of LCI, please use MQTT.
 
 [lci_client.py](lci_rmf_adapter/lci_rmf_adapter/lci_client.py) is an implementation of LCI client without ROS2.


### PR DESCRIPTION
## 概要

`paho-mqtt`ライブラリの指定バージョンを`1.6.1`に固定
Fixes #5 