### PR TITLE
Hotfix/validate floor requests

### DIFF
--- a/lci_rmf_adapter/lci_rmf_adapter/lci_client.py
+++ b/lci_rmf_adapter/lci_rmf_adapter/lci_client.py
@@ -526,6 +526,11 @@ class LciClient:
 
         payload = {'direction': direction}
 
+        if origination == destination:
+            self._logger.error(
+                f'[LCI] Same values {origination} are given for origination and destination, ignoring request.')
+            return False
+
         if origination is not None:
             payload.update({
                 'origination': origination,

--- a/lci_rmf_adapter/lci_rmf_adapter/lci_client.py
+++ b/lci_rmf_adapter/lci_rmf_adapter/lci_client.py
@@ -550,7 +550,7 @@ class LciClient:
 
     def do_open_door(self, context: LciDoorContext, direction: int = None) -> bool:
         if context._device_type == 'flap' and direction is not None:
-            return self._publish(context, 'OpenDoor', {'direciton': direction}, 20)
+            return self._publish(context, 'OpenDoor', {'direction': direction}, 20)
         else:
             return self._publish(context, 'OpenDoor', {}, 20)
 


### PR DESCRIPTION
## 概要

- #7 対応
- `do_open_door`関数内で、送信するペイロード内にtypoを発見したためこれを修正

@nabeshima 
先日私どもの実験中に発生したトラブルへの対処として、ひとまずサーバー側に悪影響を及ぼさないように、本PRのようなpublishする前の処置を追加いたました。
他の箇所（アダプタ本体側）で対処するべきなどのご意見ございましたらご教示ください。